### PR TITLE
Bug Fix: PCDLoader can't load files with \r\n LineBreaks in the header

### DIFF
--- a/examples/jsm/loaders/PCDLoader.js
+++ b/examples/jsm/loaders/PCDLoader.js
@@ -113,8 +113,8 @@ class PCDLoader extends Loader {
 		function parseHeader( data ) {
 
 			const PCDheader = {};
-			const result1 = data.search( /[\r\n]DATA\s(\S*)\s/i );
-			const result2 = /[\r\n]DATA\s(\S*)\s/i.exec( data.substr( result1 - 1 ) );
+			const result1 = data.search( /[\r\n]DATA\s(\S*)(\n|\r\n)/i );
+			const result2 = /[\r\n]DATA\s(\S*)(\n|\r\n)/i.exec( data.substr( result1 - 1 ) );
 
 			PCDheader.data = result2[ 1 ];
 			PCDheader.headerLen = result2[ 0 ].length + result1;


### PR DESCRIPTION
Related issue: None

**Description**

PCDLoader can't load files with \r\n Line Breaks in the header
![image](https://user-images.githubusercontent.com/2871136/146545574-84597b2b-9695-4435-8791-11e9df9e1b97.png)
As shown in the image above, the left file with \n Line Breaks in the header can be loaded correctly,
while the right one with \r\n cann't be loaded.
After some attempts of debugging, I find out that the regex expression used in parseHeader function cann't process such difference correctly, so I made some changes to the regex expression, now it works perfect.